### PR TITLE
Web-Configuration-Page headline customizable

### DIFF
--- a/Configuration.h
+++ b/Configuration.h
@@ -11,6 +11,7 @@
 //******************************************************************************
 
 #define HOSTNAME "QLOCKWORK"
+#define WEBSITE_TITLE "QLOCKWORK's configuration page"
 #define WIFI_SETUP_TIMEOUT 120
 #define WIFI_AP_PASS "12345678"
 #define OTA_PASS "1234"

--- a/Qlockwork.ino
+++ b/Qlockwork.ino
@@ -1696,7 +1696,7 @@ void handleRoot()
 		"</style>"
 		"</head>"
 		"<body>"
-		"<h1>" + String(HOSTNAME) + "</h1>";
+		"<h1>" + String(WEBSITE_TITLE) + "</h1>";
 #ifdef DEDICATION
 	message += DEDICATION;
 	message += "<br><br>";


### PR DESCRIPTION
Reason: I want the clock to be reachable within the network via hostname.fritz.box but want the configuration pages title to be customized (the clock was a present...)

  